### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Since a circular indicator wouldn't fit, a rectangular [KITT scanner](https://gi
 ## Integration
 ### As a fix for the system network activity indicator
 
-In your app delegate's `didFinishLaunching` method, just call
+In your app delegate's `didFinishLaunching` method, **after** initializing the window, just call
 
     UIApplication.configureLinearNetworkActivityIndicatorIfNeeded()
 


### PR DESCRIPTION
`configureLinearNetworkActivityIndicatorIfNeeded` should be called after the window has been initialized, otherwise there's no window yet, so the `configureLinearNetworkActivityIndicator` isn't called.

Sorry for the last paragraph appearing as changed - no idea what GitHub did (I edited the file straight from GitHub, for such a simple change). Oddly enough, if you selected "Display the rich diff", the last paragraph doesn't appear as changed anymore 🤷🏻‍♂️