### PR TITLE
Bump minimum iOS version to 9.

### DIFF
--- a/FTLinearActivityIndicator.podspec
+++ b/FTLinearActivityIndicator.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/futuretap/FTLinearActivityIndicator.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/ortwingentz'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.swift_version = '5.0'
 
   s.source_files = 'FTLinearActivityIndicator/Classes/**/*'

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FTLinearActivityIndicator",
     platforms: [
-        .iOS(.v8)
+        .iOS(.v9)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Support for iOS 8 and below was dropped in Xcode 12, causing it to throw a warning.

Fixes https://github.com/futuretap/FTLinearActivityIndicator/issues/11