### PR TITLE
Add simulator support.

### DIFF
--- a/FTLinearActivityIndicator/Classes/UIDevice+Extension.swift
+++ b/FTLinearActivityIndicator/Classes/UIDevice+Extension.swift
@@ -16,6 +16,10 @@ public extension UIDevice {
 			guard let value = element.value as? Int8, value != 0 else { return identifier }
 			return identifier + String(UnicodeScalar(UInt8(value)))
 		}
-		return identifier
+		// When running in simulator, identifier will be one of "i386", "x86_64", "arm64" instead of what we want.
+		switch identifier {
+		case "i386", "x86_64", "arm64": return ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? identifier
+		default: return identifier
+		}
 	}
 }


### PR DESCRIPTION
When running in a simulator, we need to read from somewhere else to know which device the simulator is simulating.

We can read the `SIMULATOR_MODEL_IDENTIFIER` environment variable to know which device we are currently running as. This will produce the exact string we need for device model identification.